### PR TITLE
fix: JSON 응답에 MSC와 BSM 모두 포함되는 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ src/main/resources/static/docs
 *.xlsx
 *.yml
 *.sh
+
+/.gemini/

--- a/src/main/java/com/gonghak98/v2/report/domain/counting/PointCalculator.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/counting/PointCalculator.java
@@ -16,10 +16,10 @@ public class PointCalculator {
         Map<AreaType, AreaCreditSummary> summaries = new EnumMap<>(AreaType.class);
 
         for (AreaType areaType : AreaType.values()) {
-            List<CompletedCourse> areaCourses = coursesByArea.getOrDefault(areaType, null);
-            if (areaCourses == null) {
+            if (!coursesByArea.containsKey(areaType)) {
                 continue;
             }
+            List<CompletedCourse> areaCourses = coursesByArea.get(areaType);
             double completedCredits = calculateTotalCredits(areaCourses);
             double requiredPoint = requiredPoints.getOrDefault(areaType, 0.0);
 

--- a/src/main/java/com/gonghak98/v2/report/domain/counting/PointCalculator.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/counting/PointCalculator.java
@@ -16,7 +16,10 @@ public class PointCalculator {
         Map<AreaType, AreaCreditSummary> summaries = new EnumMap<>(AreaType.class);
 
         for (AreaType areaType : AreaType.values()) {
-            List<CompletedCourse> areaCourses = coursesByArea.getOrDefault(areaType, List.of());
+            List<CompletedCourse> areaCourses = coursesByArea.getOrDefault(areaType, null);
+            if (areaCourses == null) {
+                continue;
+            }
             double completedCredits = calculateTotalCredits(areaCourses);
             double requiredPoint = requiredPoints.getOrDefault(areaType, 0.0);
 


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #20 

## 🛠️작업 내용
- 학점 요약 정보(`creditSummaries`)에 MSC와 BSM이 모두 포함되어 있는 것을 발견했습니다. 그래서 이 필드에 데이터를 담는 역할을 담당하는 `PointCalculator`의 `calculateCredits()` 메서드에 if문(null 체크)을 추가했습니다.
  - `getOrDefault(areaType, null)`을 통해 `MSC` 관련 학과는 `BSM`이 `null`로 반환됩니다.
  - **코드리뷰 결과, `null` 대신 Map 타입인 `coursesByArea`에 `containsKey()`를 호출하여 포함되지 않은 영역은 건너뛰는 방식으로 수정했습니다.**

### 변경전
```JSON
{
    "areaType": "MSC",
    "completedPoints": 6.0,
    "requiredPoints": 27.0,
    "relatedCourses": [
        {
            "courseId": 304,
            "name": "공업수학1",
            "year": 18,
            "semester": 2,
            "point": 3.0
        },
        {
            "courseId": 1725,
            "name": "선형대수",
            "year": 18,
            "semester": 2,
            "point": 3.0
        }
    ]
},
{
    "areaType": "BSM",
    "completedPoints": 0.0,
    "requiredPoints": 0.0,
    "relatedCourses": []
}
```

### 변경후
```JSON
{
    "areaType": "MSC",
    "completedPoints": 6.0,
    "requiredPoints": 27.0,
    "relatedCourses": [
        {
            "courseId": 304,
            "name": "공업수학1",
            "year": 18,
            "semester": 2,
            "point": 3.0
        },
        {
            "courseId": 1725,
            "name": "선형대수",
            "year": 18,
            "semester": 2,
            "point": 3.0
        }
    ]
}
```