### PR TITLE
feat: CORS 설정

### DIFF
--- a/src/main/java/com/gonghak98/v2/common/config/WebConfig.java
+++ b/src/main/java/com/gonghak98/v2/common/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.gonghak98.v2.common.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigins.toArray(new String[0]))
+                .allowedMethods("POST", "OPTIONS")
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/gonghak98/v2/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gonghak98/v2/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.gonghak98.v2.common.exception;
 
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,5 +16,13 @@ public class GlobalExceptionHandler {
                              .body(new ExceptionResponse(exceptionType.httpStatus().value(),
                                                          exceptionType.errorCode(),
                                                          exceptionType.errorMessage()));
+    }
+
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<ExceptionResponse> handleMissingParams(TypeMismatchException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.value(),
+                                                         "TYPE_MISMATCH",
+                                                         "요청이 올바른 형식이 아닙니다."));
     }
 }

--- a/src/main/java/com/gonghak98/v2/file/infrastructure/ExcelFileService.java
+++ b/src/main/java/com/gonghak98/v2/file/infrastructure/ExcelFileService.java
@@ -19,6 +19,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.tika.Tika;
+import org.apache.tika.io.TikaInputStream;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -74,7 +75,7 @@ public class ExcelFileService implements FileService {
         try (InputStream is = file.getInputStream()) {
             Tika tika = new Tika();
 
-            String mimeType = tika.detect(is);
+            String mimeType = tika.detect(TikaInputStream.get(is));
             if (!mimeType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
                 && !mimeType.equals("application/x-tika-ooxml")) {
                 throw new ExcelFileException(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE);


### PR DESCRIPTION
## 🛠️작업 내용
- 작업 내용
  - CORS 설정을 통해 브라우저의 SOP로 인해 발생하는 프론트, 백 통신 문제 해결
    - 허용할 Origin 값을 외부 설정 파일로 분리 ('dev', 'prod' 별로 허용할 Origin이 다르기 때문)
  - Tika 라이브러리 사용 시, 발생하는 WRAN 에러를 해결하기 위해 `InputStream`을 `TikaInputStream`으로 래핑
  - API 명세대로 요청하지 않을 경우, 400 Bad Request를 반환하도록 핸들러 추가
