### PR TITLE
test: 기이수 파일 업로드 시, 실패 케이스 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ out/
 *.properties
 
 src/main/resources/static/docs
+src/test/resources/file
 
 *.xlsx
 *.yml

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -36,7 +36,7 @@ include::{snippets}/create-fail-report/response-fields.adoc[]
 | 400
 | INVALID_EXCEL_FILE_TYPE
 | 올바른 기이수 성적 파일을 업로드해주세요.
-| `.xlsx`, `.xls` 가 아니거나 기이수 성적 파일을 수정했을 경우
+| `.xlsx`가 아니거나 기이수 성적 파일을 수정했을 경우
 
 | 400
 | EMPTY_EXCEL_FILE

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -35,15 +35,25 @@ include::{snippets}/create-fail-report/response-fields.adoc[]
 
 | 400
 | INVALID_EXCEL_FILE_TYPE
-| 올바른 기이수 성적 파일을 업로드해주세요.
-| `.xlsx`가 아니거나 기이수 성적 파일을 수정했을 경우
+| 올바른 파일 형식이 아닙니다.
+| 업로드 한 파일이 `.xlsx`가 아닐 경우
+
+| 400
+| INVALID_STUDENT
+| 재학생 인증에 실패했습니다.
+| 업로드 한 기이수 성적 파일의 양식이 올바르지 않은 경우
 
 | 400
 | EMPTY_EXCEL_FILE
 | 기이수 성적 파일을 업로드해주세요.
 | 비어있는 파일을 업로드할 경우
 
-| 400
+| 413
+| EXCEED_EXCEL_FILE_SIZE
+| 업로드 파일 크기는 최대 30KB를 초과할 수 없습니다.
+| 업로드한 파일 크기가 30KB를 초과하는 경우
+
+| 500
 | RETRY_EXCEL_FILE
 | 업로드 과정에서 오류가 발생했습니다. 다시 시도해주세요.
 | 파일 처리 과정에서 발생한 오류로 다시 업로드 시도

--- a/src/main/java/com/gonghak98/v2/common/exception/BaseException.java
+++ b/src/main/java/com/gonghak98/v2/common/exception/BaseException.java
@@ -2,5 +2,13 @@ package com.gonghak98.v2.common.exception;
 
 public abstract class BaseException extends RuntimeException {
 
+    protected BaseException(String message) {
+        super(message);
+    }
+
+    protected BaseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public abstract BaseExceptionType exceptionType();
 }

--- a/src/main/java/com/gonghak98/v2/common/exception/CommonExceptionType.java
+++ b/src/main/java/com/gonghak98/v2/common/exception/CommonExceptionType.java
@@ -1,0 +1,31 @@
+package com.gonghak98.v2.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonExceptionType implements BaseExceptionType {
+
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    CommonExceptionType(HttpStatus httpStatus, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorCode() {
+        return this.name();
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/gonghak98/v2/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gonghak98/v2/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,15 @@
 package com.gonghak98.v2.common.exception;
 
 import com.gonghak98.v2.file.exception.ExcelFileExceptionType;
-import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -20,8 +22,8 @@ public class GlobalExceptionHandler {
                                                          exceptionType.errorMessage()));
     }
 
-    @ExceptionHandler(FileSizeLimitExceededException.class)
-    public ResponseEntity<ExceptionResponse> handleFileSizeLimitExceededException(FileSizeLimitExceededException exception) {
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ExceptionResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException exception) {
         final BaseExceptionType exceptionType = ExcelFileExceptionType.EXCEED_EXCEL_FILE_SIZE;
         return ResponseEntity.status(exceptionType.httpStatus())
                              .body(new ExceptionResponse(exceptionType.httpStatus().value(),
@@ -40,6 +42,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
         final BaseExceptionType exceptionType = CommonExceptionType.SERVER_ERROR;
+        log.warn("서버 에러가 발생했습니다.", exception);
         return ResponseEntity.status(exceptionType.httpStatus())
                              .body(new ExceptionResponse(exceptionType.httpStatus().value(),
                                                          exceptionType.errorCode(),

--- a/src/main/java/com/gonghak98/v2/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gonghak98/v2/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.gonghak98.v2.common.exception;
 
+import com.gonghak98.v2.file.exception.ExcelFileExceptionType;
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +20,29 @@ public class GlobalExceptionHandler {
                                                          exceptionType.errorMessage()));
     }
 
+    @ExceptionHandler(FileSizeLimitExceededException.class)
+    public ResponseEntity<ExceptionResponse> handleFileSizeLimitExceededException(FileSizeLimitExceededException exception) {
+        final BaseExceptionType exceptionType = ExcelFileExceptionType.EXCEED_EXCEL_FILE_SIZE;
+        return ResponseEntity.status(exceptionType.httpStatus())
+                             .body(new ExceptionResponse(exceptionType.httpStatus().value(),
+                                                         exceptionType.errorCode(),
+                                                         exceptionType.errorMessage()));
+    }
+
     @ExceptionHandler(TypeMismatchException.class)
     public ResponseEntity<ExceptionResponse> handleMissingParams(TypeMismatchException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.value(),
                                                          "TYPE_MISMATCH",
                                                          "요청이 올바른 형식이 아닙니다."));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
+        final BaseExceptionType exceptionType = CommonExceptionType.SERVER_ERROR;
+        return ResponseEntity.status(exceptionType.httpStatus())
+                             .body(new ExceptionResponse(exceptionType.httpStatus().value(),
+                                                         exceptionType.errorCode(),
+                                                         exceptionType.errorMessage()));
     }
 }

--- a/src/main/java/com/gonghak98/v2/file/exception/ExcelFileException.java
+++ b/src/main/java/com/gonghak98/v2/file/exception/ExcelFileException.java
@@ -2,12 +2,20 @@ package com.gonghak98.v2.file.exception;
 
 import com.gonghak98.v2.common.exception.BaseException;
 import com.gonghak98.v2.common.exception.BaseExceptionType;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class ExcelFileException extends BaseException {
 
     private final ExcelFileExceptionType exceptionType;
+
+    public ExcelFileException(ExcelFileExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public ExcelFileException(ExcelFileExceptionType exceptionType, Throwable cause) {
+        super(exceptionType.errorMessage(), cause);
+        this.exceptionType = exceptionType;
+    }
 
     @Override
     public BaseExceptionType exceptionType() {

--- a/src/main/java/com/gonghak98/v2/file/exception/ExcelFileExceptionType.java
+++ b/src/main/java/com/gonghak98/v2/file/exception/ExcelFileExceptionType.java
@@ -7,10 +7,12 @@ public enum ExcelFileExceptionType implements BaseExceptionType {
 
     INVALID_STUDENT(HttpStatus.BAD_REQUEST, "재학생 인증에 실패했습니다."),
 
-    INVALID_EXCEL_FILE_TYPE(HttpStatus.BAD_REQUEST, "올바른 기이수 성적 파일을 업로드해주세요."),
+    INVALID_EXCEL_FILE_TYPE(HttpStatus.BAD_REQUEST, "올바른 파일 형식이 아닙니다."),
     EMPTY_EXCEL_FILE(HttpStatus.BAD_REQUEST, "기이수 성적 파일을 업로드해주세요."),
-    RETRY_EXCEL_FILE(HttpStatus.BAD_REQUEST, "업로드 과정에서 오류가 발생했습니다. 다시 시도해주세요."),
-    EXCEED_EXCEL_FILE_SIZE(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 파일 크기는 최대 30KB를 초과할 수 없습니다.");
+    EXCEED_EXCEL_FILE_SIZE(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 파일 크기는 최대 30KB를 초과할 수 없습니다."),
+
+    RETRY_EXCEL_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "업로드 과정에서 오류가 발생했습니다. 다시 시도해주세요.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/gonghak98/v2/file/infrastructure/ExcelFileService.java
+++ b/src/main/java/com/gonghak98/v2/file/infrastructure/ExcelFileService.java
@@ -60,7 +60,6 @@ public class ExcelFileService implements FileService {
     }
 
     //업로드 파일 검증
-
     private void validateExcelFileFormat(MultipartFile file, String extension) throws ExcelFileException {
         if (file.isEmpty()) {
             throw new ExcelFileException(ExcelFileExceptionType.EMPTY_EXCEL_FILE);
@@ -84,7 +83,7 @@ public class ExcelFileService implements FileService {
                 throw new ExcelFileException(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE);
             }
         } catch (IOException e) {
-            throw new ExcelFileException(ExcelFileExceptionType.RETRY_EXCEL_FILE);
+            throw new ExcelFileException(ExcelFileExceptionType.RETRY_EXCEL_FILE, e);
         }
     }
 
@@ -96,13 +95,13 @@ public class ExcelFileService implements FileService {
         try (InputStream is = file.getInputStream()) {
             return new XSSFWorkbook(is).getSheetAt(0);
         } catch (IOException e) {
-            throw new ExcelFileException(ExcelFileExceptionType.RETRY_EXCEL_FILE);
+            throw new ExcelFileException(ExcelFileExceptionType.RETRY_EXCEL_FILE, e);
         } catch (POIXMLException e) {
-            throw new ExcelFileException(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE);
+            throw new ExcelFileException(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE, e);
         } catch (Exception e) {
             log.info("에러 메시지 {}", e.getMessage());
             // TODO 추후 로그 남기기
-            throw new ExcelFileException(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE);
+            throw new ExcelFileException(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE, e);
         }
     }
 

--- a/src/test/java/com/gonghak98/v2/acceptance/ReportsApiAcceptanceTest.java
+++ b/src/test/java/com/gonghak98/v2/acceptance/ReportsApiAcceptanceTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
+import com.gonghak98.v2.file.exception.ExcelFileExceptionType;
 import io.restassured.RestAssured;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.builder.RequestSpecBuilder;
@@ -94,8 +95,31 @@ class ReportsApiAcceptanceTest {
     class 기이수_성적파일_업로드_실패 {
 
         @Test
-        @DisplayName("400 BadRequest와 에러 응답이 반환된다.")
+        @DisplayName("xlsx 확장자가 아닌 파일을 업로드하면, 400 BadRequest와 에러 응답이 반환된다.")
         void 성적_업로드_예외_테스트() throws IOException {
+            //when
+            final Response response = RestAssured.given(spec)
+                                                 .filter(document("create-fail-report", responseFields(
+                                                     fieldWithPath("httpStatusCode").description("HTTP 상태 코드"),
+                                                     fieldWithPath("errorCode").description("에러 코드"),
+                                                     fieldWithPath("errorMessage").description("에러 메시지"))
+                                                 ))
+                                                 .multiPart(department)
+                                                 .multiPart(entranceYear)
+                                                 .multiPart("file", 인수테스트_업로드_파일_생성("/file/PDF샘플자료.pdf"))
+                                                 .when()
+                                                 .post("/api/reports")
+                                                 .then().log().all()
+                                                 .extract().response();
+
+            //then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(response.getBody().jsonPath().getString("errorCode")).isEqualTo(ExcelFileExceptionType.INVALID_EXCEL_FILE_TYPE.name());
+        }
+
+        @Test
+        @DisplayName("기이수 성적파일이 아닌 다른 엑셀 파일을 업로드하면, 400 BadRequest와 에러 응답이 반환된다.")
+        void 성적_업로드_예외_테스트2() throws IOException {
             //when
             final Response response = RestAssured.given(spec)
                                                  .filter(document("create-fail-report", responseFields(
@@ -113,6 +137,25 @@ class ReportsApiAcceptanceTest {
 
             //then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(response.getBody().jsonPath().getString("errorCode")).isEqualTo(ExcelFileExceptionType.INVALID_STUDENT.name());
+        }
+
+        @Test
+        @DisplayName("업로드 파일이 최대 업로드 크기를 초과하면, 413 Payload Too Large와 에러 응답이 반환된다.")
+        void 성적_업로드_예외_테스트3() throws IOException {
+            //when
+            final Response response = RestAssured.given(spec)
+                                                 .multiPart(department)
+                                                 .multiPart(entranceYear)
+                                                 .multiPart("file", 인수테스트_업로드_파일_생성("/file/30KB_초과_샘플.xlsx"))
+                                                 .when()
+                                                 .post("/api/reports")
+                                                 .then().log().all()
+                                                 .extract().response();
+
+            //then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+            assertThat(response.getBody().jsonPath().getString("errorCode")).isEqualTo(ExcelFileExceptionType.EXCEED_EXCEL_FILE_SIZE.name());
         }
     }
 }


### PR DESCRIPTION
## 🛠️작업 내용
- 비즈니스 예외 발생 시, API 응답에 에러코드 및 메시지가 반환되지 않는 문제를 발견했고, 이를 위한 인수 테스트에 실패 케이스를 추가했습니다.
- REST DOCS 문서의 에러 코드표를 업데이트했습니다.
- try-catch에서 비즈니스 예외로 감쌀 때, 발생한 exception을 함께 전달하도록 생성자를 추가했습니다.
- `GlobalExceptionHandler`에서 저수준 예외(톰캣 레벨 예외 : `FileSizeLimitExceededException`)가 아닌 스프링 추상화 예외(`MaxUploadSizeExceededException`)를 핸들링하여 정상적으로 API 예외처리를 하도록 수정했습니다.

### 톰캣 -> 스프링 컨테이너로 진입 시, 예외가 감싸지는 부분
<img width="1126" height="430" alt="image" src="https://github.com/user-attachments/assets/b65d7858-08e3-49b9-81ec-37642a47bbc1" />
- 톰캣에서 발생한 저수준 예외(`Cause by` 부분)가 `디스패처 서블릿 -> 리졸버`를 지나면서 스프링 예외로 감싸지는 것을 알 수 있습니다.