### PR TITLE
fix: 전문교양 영역 검사 로직 오류 수정

### DIFF
--- a/src/main/java/com/gonghak98/v2/report/domain/abeek/gyoyang/ProGyoyang.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/abeek/gyoyang/ProGyoyang.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 
 public class ProGyoyang implements Gyoyang {
 
+    private static final int THREE_ESSENTIAL_TOTAL_CREDIT = 8; // 문제해결을위한글쓰기와발표(3) + 서양철학:쟁점과토론(3) + 대학영어(2)
+    private static final int ELECTIVE_MIN_CREDIT = 6; // 3학점인 인증선택 과목을 최소 2개 수강
+
     private final List<Course> essentialCourses;
     private final List<Course> electiveCourses;
 
@@ -32,31 +35,37 @@ public class ProGyoyang implements Gyoyang {
     @Override
     public void checkAllCourses(List<CompletedCourse> completedCourses, AreaCheckResult areaCheckResult) {
         Set<String> completedCourseIds = completedCourses.stream()
-                                                          .map(CompletedCourse::getCode)
-                                                          .collect(Collectors.toSet());
-        int completedEssentialCount = 0;
-        int completedElectiveCount = 0;
-        double totalCredit = 0.0;
+                                                         .map(CompletedCourse::getCode)
+                                                         .collect(Collectors.toSet());
+        double completedEssentialCredit = 0;
+        double completedElectiveCredit = 0;
 
         for (Course course : essentialCourses) {
             if (completedCourseIds.contains(course.getCode())) {
-                completedEssentialCount++;
-                totalCredit += course.getCredit();
+                completedEssentialCredit += course.getCredit();
             }
         }
         for (Course course : electiveCourses) {
             if (completedCourseIds.contains(course.getCode())) {
-                completedElectiveCount++;
-                totalCredit += course.getCredit();
+                completedElectiveCredit += course.getCredit();
             }
         }
 
-        boolean isEssentialSatisfied = (completedEssentialCount == essentialCourses.size());
-        boolean isElectiveSatisfied = completedElectiveCount >= 2;
-        boolean isMinCreditSatisfied = totalCredit >= minCredit;
-        boolean isAllSatisfied = isMinCreditSatisfied && isEssentialSatisfied && isElectiveSatisfied;
+        boolean isSatisfiedOnlyEssential = checkOnlyEssential(completedEssentialCredit, completedElectiveCredit);
+        boolean isSatisfiedEssentialAndElective = checkEssentialAndElective(completedEssentialCredit, completedElectiveCredit);
 
-        areaCheckResult.passResults().put(AbeekType.GYOYANG, isAllSatisfied);
+        areaCheckResult.passResults().put(AbeekType.GYOYANG, (isSatisfiedOnlyEssential || isSatisfiedEssentialAndElective));
+    }
+
+    // 2021년 이전의 전문교양 영역 조건 검사 : 6개의 인증필수 과목을 이수했는지 검사
+    private boolean checkOnlyEssential(double completedEssentialCredit, double completedElectiveCredit) {
+        // 2021년 이전의 경우, 전문교양 영역을 수강한다면 인증선택 과목은 존재하지 않아야 한다.
+        return (completedEssentialCredit >= minCredit) && (completedElectiveCredit == 0);
+    }
+
+    // 2022년 이후의 전문교양 영역 조건 검사 : 3개의 인증필수 과목을 이수했는지 검사 + 인증선택 2과목 이상 이수했는지 검사
+    private boolean checkEssentialAndElective(double completedEssentialCredit, double completedElectiveCredit) {
+        return (completedEssentialCredit >= THREE_ESSENTIAL_TOTAL_CREDIT) && (completedElectiveCredit >= ELECTIVE_MIN_CREDIT);
     }
 
     @Override

--- a/src/main/java/com/gonghak98/v2/report/domain/abeek/gyoyang/ProGyoyang.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/abeek/gyoyang/ProGyoyang.java
@@ -51,16 +51,16 @@ public class ProGyoyang implements Gyoyang {
             }
         }
 
-        boolean isSatisfiedOnlyEssential = checkOnlyEssential(completedEssentialCredit, completedElectiveCredit);
+        boolean isSatisfiedOnlyEssential = checkOnlyEssential(completedEssentialCredit);
         boolean isSatisfiedEssentialAndElective = checkEssentialAndElective(completedEssentialCredit, completedElectiveCredit);
 
         areaCheckResult.passResults().put(AbeekType.GYOYANG, (isSatisfiedOnlyEssential || isSatisfiedEssentialAndElective));
     }
 
     // 2021년 이전의 전문교양 영역 조건 검사 : 6개의 인증필수 과목을 이수했는지 검사
-    private boolean checkOnlyEssential(double completedEssentialCredit, double completedElectiveCredit) {
+    private boolean checkOnlyEssential(double completedEssentialCredit) {
         // 2021년 이전의 경우, 전문교양 영역을 수강한다면 인증선택 과목은 존재하지 않아야 한다.
-        return (completedEssentialCredit >= minCredit) && (completedElectiveCredit == 0);
+        return (completedEssentialCredit >= minCredit);
     }
 
     // 2022년 이후의 전문교양 영역 조건 검사 : 3개의 인증필수 과목을 이수했는지 검사 + 인증선택 2과목 이상 이수했는지 검사

--- a/src/test/java/com/gonghak98/v2/abeek/fixture/GyoyangFixture.java
+++ b/src/test/java/com/gonghak98/v2/abeek/fixture/GyoyangFixture.java
@@ -10,6 +10,10 @@ public class GyoyangFixture {
     public static Gyoyang createProGyoyang() {
 
         List<Course> essentialCourses = List.of(
+            Course.builder().code("010352").name("English Listening Practice 1").credit(2.0).build(),
+            Course.builder().code("010354").name("English Reading Practice 1").credit(2.0).build(),
+            Course.builder().code("008364").name("세종사회봉사1").credit(1.0).build(),
+            Course.builder().code("009489").name("세계사:인간과문명").credit(3.0).build(),
             Course.builder().code("009067").name("문제해결을위한글쓰기와발표").credit(3.0).build(),
             Course.builder().code("009068").name("서양철학:쟁점과토론").credit(3.0).build(),
             Course.builder().code("011304").name("대학영어").credit(2.0).build()

--- a/src/test/java/com/gonghak98/v2/abeek/gyoyang/ProGyoyangTest.java
+++ b/src/test/java/com/gonghak98/v2/abeek/gyoyang/ProGyoyangTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -19,7 +20,55 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ProGyoyangTest {
 
     @Nested
-    class 전자정보통신공학과 {
+    @DisplayName("2021년 이전의 전문교양 영역 조건 검사")
+    class Until2021 {
+
+        @DisplayName("필수 과목을 모두 이수하면, 전문교양 영역을 만족한다.")
+        @Test
+        void 전문교양_영역_검사() {
+            //given
+            List<CompletedCourse> studentCourses = List.of(
+                CompletedCourse.builder().code("010352").name("English Listening Practice 1").build(),
+                CompletedCourse.builder().code("010354").name("English Reading Practice 1").build(),
+                CompletedCourse.builder().code("008364").name("세종사회봉사1").build(),
+                CompletedCourse.builder().code("009489").name("세계사:인간과문명").build(),
+                CompletedCourse.builder().code("009067").name("문제해결을위한글쓰기와발표").build(),
+                CompletedCourse.builder().code("009068").name("서양철학:쟁점과토론").build()
+            );
+            AreaCheckResult areaCheckResult = GivenObjectFixture.createCheckResult();
+            Gyoyang gyoyang = createProGyoyang();
+
+            //when
+            gyoyang.checkAllCourses(studentCourses, areaCheckResult);
+
+            //then
+            assertThat(areaCheckResult.passResults().get(AbeekType.GYOYANG)).isTrue();
+        }
+
+        @DisplayName("필수 과목을 모두 이수하지 못하면, 전문교양 영역을 만족하지 못한다.")
+        @Test
+        void 전문교양_영역_실패() {
+            //given
+            List<CompletedCourse> studentCourses = List.of(
+                CompletedCourse.builder().code("010352").name("English Listening Practice 1").build(),
+                CompletedCourse.builder().code("010354").name("English Reading Practice 1").build(),
+                CompletedCourse.builder().code("008364").name("세종사회봉사1").build(),
+                CompletedCourse.builder().code("009489").name("세계사:인간과문명").build()
+            );
+            AreaCheckResult areaCheckResult = GivenObjectFixture.createCheckResult();
+            Gyoyang gyoyang = createProGyoyang();
+
+            //when
+            gyoyang.checkAllCourses(studentCourses, areaCheckResult);
+
+            //then
+            assertThat(areaCheckResult.passResults().get(AbeekType.GYOYANG)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("2022년 이후의 전문교양 영역 조건 검사")
+    class From2022 {
 
         @DisplayName("필수 과목을 모두 이수하고, 선택 교과목 중 2과목 이상을 포함해 14학점 이상 이수하면, 전문교양 영역을 만족한다.")
         @MethodSource("provideAllEssentialAndSufficientElectiveCourses")

--- a/src/test/java/com/gonghak98/v2/abeek/gyoyang/ProGyoyangTest.java
+++ b/src/test/java/com/gonghak98/v2/abeek/gyoyang/ProGyoyangTest.java
@@ -45,6 +45,30 @@ class ProGyoyangTest {
             assertThat(areaCheckResult.passResults().get(AbeekType.GYOYANG)).isTrue();
         }
 
+        @DisplayName("필수 과목을 모두 이수하고, 선택 과목을 추가로 이수하더라도 전문교양 영역을 만족한다.")
+        @Test
+        void 전문교양_영역_검사2() {
+            //given
+            List<CompletedCourse> studentCourses = List.of(
+                CompletedCourse.builder().code("010352").name("English Listening Practice 1").build(),
+                CompletedCourse.builder().code("010354").name("English Reading Practice 1").build(),
+                CompletedCourse.builder().code("008364").name("세종사회봉사1").build(),
+                CompletedCourse.builder().code("009489").name("세계사:인간과문명").build(),
+                CompletedCourse.builder().code("009067").name("문제해결을위한글쓰기와발표").build(),
+                CompletedCourse.builder().code("009068").name("서양철학:쟁점과토론").build(),
+
+                CompletedCourse.builder().code("011313").name("경제학").build()
+            );
+            AreaCheckResult areaCheckResult = GivenObjectFixture.createCheckResult();
+            Gyoyang gyoyang = createProGyoyang();
+
+            //when
+            gyoyang.checkAllCourses(studentCourses, areaCheckResult);
+
+            //then
+            assertThat(areaCheckResult.passResults().get(AbeekType.GYOYANG)).isTrue();
+        }
+
         @DisplayName("필수 과목을 모두 이수하지 못하면, 전문교양 영역을 만족하지 못한다.")
         @Test
         void 전문교양_영역_실패() {


### PR DESCRIPTION
## 🔧연결된 이슈
- close #35 

## 🛠️작업 내용
- 전문교양 영역 검사를 담당하는 객체인 `ProGyoyang`이 조건 만족 여부(True/False)를 검사함에 있어 **21년도 이전 기준과 22년도 이후 기준 두 가지 조건을 검사하도록 수정**했습니다.
  - 전문교양의 경우, **본인의 입학년도에 맞는 졸업요건을 만족하도록 수강해야 하기 때문에** 21년도의 전문교양 영역을 기준으로 이수하고, 25년도 공학인증 기준으로 검사하더라도 **전문교양 영역은 Pass 처리됩니다.**