### PR TITLE
fix: 전공 영역 검사 시, 설계 과목의 전공학점을 반영하도록 수정

### DIFF
--- a/src/main/java/com/gonghak98/v2/report/controller/dto/ReportResponse.java
+++ b/src/main/java/com/gonghak98/v2/report/controller/dto/ReportResponse.java
@@ -86,6 +86,7 @@ public class ReportResponse {
         private int year;
         private int semester;
         private double credit;
+        private double designCredit;
 
         public static RelatedCourseDto from(CompletedCourse completedCourse) {
             return RelatedCourseDto.builder()
@@ -94,6 +95,7 @@ public class ReportResponse {
                                    .year(completedCourse.getYear())
                                    .semester(completedCourse.getSemester())
                                    .credit(completedCourse.getCredit())
+                                   .designCredit(completedCourse.getDesignCredit())
                                    .build();
         }
     }

--- a/src/main/java/com/gonghak98/v2/report/domain/abeek/Abeek.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/abeek/Abeek.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -29,11 +28,7 @@ public class Abeek {
     public AbeekCheckResult checkAllCourses(List<CompletedCourse> completedCourses) {
         AreaCheckResult areaCheckResult = checkAreaRequirements(completedCourses);
 
-        Map<AbeekType, List<CompletedCourse>> coursesByAbeekType = completedCourses.stream()
-                                                                                   .collect(Collectors.groupingBy(CompletedCourse::getAbeekType,
-                                                                                                                  () -> new EnumMap<>(AbeekType.class),
-                                                                                                                  Collectors.toList()
-                                                                                   ));
+        Map<AbeekType, List<CompletedCourse>> coursesByAbeekType = categorizeCompletedCourseByAbeekType(completedCourses);
         Map<AbeekType, Double> requiredCredits = collectRequiredCredits();
         CountingResult creditCountingResult = CreditCalculator.calculateCredits(coursesByAbeekType, requiredCredits);
 
@@ -42,6 +37,19 @@ public class Abeek {
             areaCheckResult.nonPassResults(),
             creditCountingResult.creditSummaries()
         );
+    }
+
+    private Map<AbeekType, List<CompletedCourse>> categorizeCompletedCourseByAbeekType(List<CompletedCourse> completedCourses) {
+        Map<AbeekType, List<CompletedCourse>> coursesByAbeekType = new EnumMap<>(AbeekType.class);
+        for (CompletedCourse course : completedCourses) {
+            AbeekType abeekType = course.getAbeekType();
+            if (abeekType == AbeekType.DESIGN) {
+                // 설계 기이수 과목은 전공 영역에도 포함
+                coursesByAbeekType.computeIfAbsent(AbeekType.MAJOR, k -> new ArrayList<>()).add(course);
+            }
+            coursesByAbeekType.computeIfAbsent(abeekType, k -> new ArrayList<>()).add(course);
+        }
+        return coursesByAbeekType;
     }
 
     private AreaCheckResult checkAreaRequirements(List<CompletedCourse> completedCourses) {

--- a/src/main/java/com/gonghak98/v2/report/domain/abeek/major/Major.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/abeek/major/Major.java
@@ -17,12 +17,12 @@ public class Major {
         boolean isSatisfied = rules.stream()
                                    .allMatch(rule -> rule.isSatisfied(completedCourses));
 
-        double majorTotalCredit = completedCourses.stream()
-                                                  .filter(course -> course.getAbeekType() == AbeekType.MAJOR)
+        double totalCredit = completedCourses.stream()
+                                                  .filter(course -> (course.getAbeekType() == AbeekType.MAJOR) || (course.getAbeekType() == AbeekType.DESIGN))
                                                   .mapToDouble(CompletedCourse::getCredit)
                                                   .sum();
 
-        areaCheckResult.passResults().put(AbeekType.MAJOR, isSatisfied && (majorTotalCredit >= minCredit));
+        areaCheckResult.passResults().put(AbeekType.MAJOR, isSatisfied && (totalCredit >= minCredit));
     }
 
     public Double getRequiredCredits() {

--- a/src/main/java/com/gonghak98/v2/report/domain/abeek/major/Major.java
+++ b/src/main/java/com/gonghak98/v2/report/domain/abeek/major/Major.java
@@ -18,9 +18,9 @@ public class Major {
                                    .allMatch(rule -> rule.isSatisfied(completedCourses));
 
         double totalCredit = completedCourses.stream()
-                                                  .filter(course -> (course.getAbeekType() == AbeekType.MAJOR) || (course.getAbeekType() == AbeekType.DESIGN))
-                                                  .mapToDouble(CompletedCourse::getCredit)
-                                                  .sum();
+                                             .filter(course -> (course.getAbeekType() == AbeekType.MAJOR) || (course.getAbeekType() == AbeekType.DESIGN))
+                                             .mapToDouble(CompletedCourse::getCredit)
+                                             .sum();
 
         areaCheckResult.passResults().put(AbeekType.MAJOR, isSatisfied && (totalCredit >= minCredit));
     }

--- a/src/test/java/com/gonghak98/v2/abeek/major/MajorTest.java
+++ b/src/test/java/com/gonghak98/v2/abeek/major/MajorTest.java
@@ -9,31 +9,51 @@ import com.gonghak98.v2.report.domain.abeek.dto.AreaCheckResult;
 import com.gonghak98.v2.report.domain.abeek.major.Major;
 import com.gonghak98.v2.report.domain.abeek.rule.Rule;
 import com.gonghak98.v2.report.domain.student.CompletedCourse;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("전공영역 테스트")
 class MajorTest {
 
-    @Nested
-    class 전자정보통신공학과 {
+    @DisplayName("MAJOR와 DESIGN 영역의 기이수 과목의 총 이수 학점이 최소 학점 이상이면 전공 영역의 조건을 만족한다.")
+    @Test
+    void 전공_설계_영역_검사_성공() {
+        //given
+        List<CompletedCourse> completedCourses = new ArrayList<>();
+        completedCourses.addAll(GivenObjectFixture.createCompletedCoursesWithThreeCredit(3, AbeekType.MAJOR));
+        completedCourses.addAll(GivenObjectFixture.createCompletedCoursesWithThreeCredit(3, AbeekType.DESIGN));
 
-        @DisplayName("전공영역은 설계, 실험, 일반, 선후수 세부요건을 검사할 수 있다.")
-        @Test
-        void 전공영역_검사() {
-            //given
-            List<CompletedCourse> completedCourses = GivenObjectFixture.createCompletedCoursesWithThreeCredit(5, AbeekType.MAJOR);
-            List<Rule> rules = List.of(new TestRequirementRule());
-            Major major = new Major(rules, 3 * 5);
+        List<Rule> rules = List.of(new TestRequirementRule());
+        Major major = new Major(rules, 3 * 5);
 
-            AreaCheckResult areaCheckResult = GivenObjectFixture.createCheckResult();
+        AreaCheckResult areaCheckResult = GivenObjectFixture.createCheckResult();
 
-            //when
-            major.checkAllCourses(completedCourses, areaCheckResult);
+        //when
+        major.checkAllCourses(completedCourses, areaCheckResult);
 
-            //then
-            assertThat(areaCheckResult.passResults().get(AbeekType.MAJOR)).isTrue();
-        }
+        //then
+        assertThat(areaCheckResult.passResults().get(AbeekType.MAJOR)).isTrue();
+    }
+
+    @DisplayName("MAJOR와 DESIGN 영역의 기이수 과목의 총 이수 학점이 최소 학점 미만이면 전공 영역의 조건을 만족하지 못한다.")
+    @Test
+    void 전공_설계_영역_검사_실패() {
+        //given
+        List<CompletedCourse> completedCourses = new ArrayList<>();
+        completedCourses.addAll(GivenObjectFixture.createCompletedCoursesWithThreeCredit(1, AbeekType.MAJOR));
+        completedCourses.addAll(GivenObjectFixture.createCompletedCoursesWithThreeCredit(1, AbeekType.DESIGN));
+
+        List<Rule> rules = List.of(new TestRequirementRule());
+        Major major = new Major(rules, 3 * 5);
+
+        AreaCheckResult areaCheckResult = GivenObjectFixture.createCheckResult();
+
+        //when
+        major.checkAllCourses(completedCourses, areaCheckResult);
+
+        //then
+        assertThat(areaCheckResult.passResults().get(AbeekType.MAJOR)).isFalse();
     }
 }


### PR DESCRIPTION
## 🔧연결된 이슈
- close #37

## 🛠️작업 내용
- `Major` 클래스의 검사 로직 실행 시, `AbeekType.DESIGN`의 `credit`도 총 이수 학점에 포함하도록 수정했습니다.
  - 전공 영역의 총 이수 학점 = **전공 과목의 전공 학점 + 설계 과목의 전공 학점**
- API 응답 중 `creditSummaries`에 포함되는 기이수 과목 리스트에 `designCredit` 필드가 추가됐습니다.
  - 설계 과목은 **전공 영역과 설계 영역에 모두 포함되며, 표시되는 학점 값은 다음과 같습니다.**
    - 설계 영역 : 멀티미디어설계 - `설계 2학점`
    - 전공 영역 : 멀티미디어설계 - `3학점`

### 수정된 API 응답 형식
<img width="479" height="385" alt="image" src="https://github.com/user-attachments/assets/59ee6fc1-ea6e-4064-bebe-516ef0a64ead" />
