### PR TITLE
fix: 전정통 22년도 선후수 검사 불일치 문제 해결

### DIFF
--- a/src/main/resources/db/migration/V2.1.1__update_eie_2022_requirement.sql
+++ b/src/main/resources/db/migration/V2.1.1__update_eie_2022_requirement.sql
@@ -1,4 +1,20 @@
+-- 전자정보통신공학과 2022학년도 선후수 중 일반물리학및실험2 -> 전자기1이 아니라 일반물리학2 -> 전자기1로 변경
+/*
+변경 전
 {
+    "afterCode": "009649",
+    "beforeCode": "002649"
+}
+
+변경 후
+{
+    "afterCode": "009649",
+    "beforeCode": "002641"
+}
+*/
+
+update gonghak_requirement
+set detail = '{
   "totalRequirement": {
     "minCredit": 98
   },
@@ -100,3 +116,5 @@
     ]
   }
 }
+'
+where id = 3;

--- a/src/main/resources/db/migration/V2.1.1__update_eie_2022_requirement.sql
+++ b/src/main/resources/db/migration/V2.1.1__update_eie_2022_requirement.sql
@@ -13,8 +13,8 @@
 }
 */
 
-update gonghak_requirement
-set detail = '{
+UPDATE gonghak_requirement
+SET detail = '{
   "totalRequirement": {
     "minCredit": 98
   },
@@ -117,4 +117,4 @@ set detail = '{
   }
 }
 '
-where id = 3;
+WHERE department_id = (SELECT id FROM department WHERE name = '전자정보통신공학과') AND entrance_year = 2022;


### PR DESCRIPTION
## 🛠️작업 내용
- 고객 문의사항을 바탕으로 DB에 잘못 기입된 선후수 과목 코드를 수정했습니다. (전정통 22년도 선후수 조건)
  - **AS-IS)** "일반물리학및실험2 -> 전자기1"
  - **TO-BE)** "일반물리학2 -> 전자기1"
- 추후 JSON 데이터를 새로 추가할 때 **요건 표와 이수체계도의 더블체크가 필요합니다.**

### 요건 표
<img width="671" height="279" alt="image" src="https://github.com/user-attachments/assets/1da63c27-060a-455a-9192-0b46c4a86f90" />

### 이수체계도
<img width="646" height="278" alt="image" src="https://github.com/user-attachments/assets/da527acd-a367-4cf6-ad1a-e65e2e14327b" />

